### PR TITLE
Round before calculating length (Fixes #46)

### DIFF
--- a/src/fmtcore.jl
+++ b/src/fmtcore.jl
@@ -149,10 +149,6 @@ function _pfmt_float(out::IO, sch::Char, zs::Integer, intv::Real, decv::Real, pr
         _repwrite(out, '0', zs)
     end
     idecv = round(Integer, decv * exp10(prec))
-    if idecv == exp10(prec)
-        intv += 1
-        idecv = 0
-    end
     # print integer part
     if intv == 0
         write(out, '0')
@@ -173,10 +169,10 @@ end
 
 function _pfmt_f(out::IO, fs::FormatSpec, x::AbstractFloat)
     # separate sign, integer, and decimal part
-    ax = abs(x)
+    rax = round(abs(x), fs.prec)
     sch = _signchar(x, fs.sign)
-    intv = trunc(Integer, ax)
-    decv = ax - intv
+    intv = trunc(Integer, rax)
+    decv = rax - intv
 
     # calculate length
     xlen = _ndigits(intv, _Dec()) + 1 + fs.prec

--- a/test/fmtspec.jl
+++ b/test/fmtspec.jl
@@ -123,6 +123,7 @@ fs = FormatSpec("d")
 
 @test fmt(".2f", 0.999) == "1.00"
 @test fmt(".2f", 0.996) == "1.00"
+@test fmt("6.2f", 9.999) == " 10.00"
 # Floating point error can upset this one (i.e. 0.99500000 or 0.994999999)
 @test (fmt(".2f", 0.995) == "1.00" || fmt(".2f", 0.995) == "0.99")
 @test fmt(".2f", 0.994) == "0.99"


### PR DESCRIPTION
Fixes #46 #51.  Round floating point numbers before calculating the length.  When 9.999 is rounded to 10.00 the correct length is calculated.