### PR TITLE
Revert "Update calls to round, change signif to round"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 This package offers Python-style general formatting and c-style numerical formatting (for speed).
 
-[![Formatting](http://pkg.julialang.org/badges/Formatting_0.6.svg)](http://pkg.julialang.org/?pkg=Formatting&ver=0.6)
-[![Formatting](http://pkg.julialang.org/badges/Formatting_0.7.svg)](http://pkg.julialang.org/?pkg=Formatting&ver=0.7)
+[![Build Status](https://travis-ci.org/JuliaIO/Formatting.jl.svg?branch=master)](https://travis-ci.org/JuliaIO/Formatting.jl)
+[![Formatting](http://pkg.julialang.org/badges/Formatting_0.4.svg)](http://pkg.julialang.org/?pkg=Formatting&ver=0.4)
+[![Formatting](http://pkg.julialang.org/badges/Formatting_0.5.svg)](http://pkg.julialang.org/?pkg=Formatting&ver=0.5)
 
 ---------------
 

--- a/src/fmtcore.jl
+++ b/src/fmtcore.jl
@@ -171,8 +171,7 @@ end
 
 function _pfmt_f(out::IO, fs::FormatSpec, x::AbstractFloat)
     # separate sign, integer, and decimal part
-    rax = (@static VERSION < v"0.7.0-DEV.4804" ? round(abs(x), fs.prec) :
-           round(abs(x); digits=fs.prec))
+    rax = round(abs(x), fs.prec)
     sch = _signchar(x, fs.sign)
     intv = trunc(Integer, rax)
     decv = rax - intv
@@ -219,36 +218,6 @@ function _pfmt_floate(out::IO, sch::Char, zs::Integer, u::Real, prec::Int, e::In
 end
 
 
-# Pull in definition of signif from v0.6.2 base, since it is currently broken for
-# BigFloat and DecFP (at least) on master
-
-@static if VERSION >= v"0.7.0-DEV.4804"
-# adapted from Matlab File Exchange roundsd: http://www.mathworks.com/matlabcentral/fileexchange/26212
-# for round, og is the power of 10 relative to the decimal point
-# for signif, og is the absolute power of 10
-# digits and base must be integers, x must be convertable to float
-
-function signif(x::Real, digits::Integer, base::Integer=10)
-    digits < 1 && throw(DomainError())
-
-    x = float(x)
-    (x == 0 || !isfinite(x)) && return x
-    if base == 10
-        e = floor(log10(abs(x)) - digits + 1.)
-        og = oftype(x, exp10(abs(e)))
-    elseif base == 2
-        e = exponent(abs(x)) - digits + 1.
-        og = oftype(x, exp2(abs(e)))
-    else
-        e = floor(log(base, abs(x)) - digits + 1.)
-        og = oftype(x, float(base) ^ abs(e))
-    end
-    # for numeric stability
-    r = e >= 0 ? round(x/og)*og : round(x*og)/og
-    isfinite(r) ? r : x
-end
-end
-
 function _pfmt_e(out::IO, fs::FormatSpec, x::AbstractFloat)
     # extract sign, significand, and exponent
     ax = abs(x)
@@ -257,7 +226,7 @@ function _pfmt_e(out::IO, fs::FormatSpec, x::AbstractFloat)
         e = 0
         u = zero(x)
     else
-        rax = signif(ax, fs.prec + 1) # round(ax; sigdigits = fs.prec + 1)
+        rax = signif(ax, fs.prec + 1)
         e = floor(Integer, log10(rax))  # exponent
         u = rax * exp10(-e)  # significand
     end


### PR DESCRIPTION
Reverts JuliaIO/Formatting.jl#56.  I am reverting this PR.  https://github.com/JuliaLang/julia/pull/26760 has been merged which should fix the `signif` issue.  When https://github.com/JuliaLang/Compat.jl/pull/530 is merged I will use `Compat` to get this working with 0.6/0.7.  I had also read this code in Base, and I assumed it was OK to use.