### PR TITLE
format Symbols without leading colon 

### DIFF
--- a/src/fmtspec.jl
+++ b/src/fmtspec.jl
@@ -166,6 +166,7 @@ mutable struct _Bin end
 
 _srepr(x) = repr(x)
 _srepr(x::AbstractString) = x
+_srepr(x::Symbol) = string(x)
 _srepr(x::Char) = string(x)
 _srepr(x::Enum) = string(x)
 

--- a/test/fmtspec.jl
+++ b/test/fmtspec.jl
@@ -52,6 +52,11 @@ fs = FormatSpec("d")
 @test fmt("*<5s", "abc") == "abc**"
 @test fmt("⋆<5s", "αβγ") == "αβγ⋆⋆"
 
+# format symbol
+
+@test fmt("", :abc) == "abc"
+@test fmt("s", :abc) == "abc"
+
 # format char
 
 @test fmt("", 'c') == "c"


### PR DESCRIPTION
makes output consistent with regular Julia string interpolation