### PR TITLE
Mark package as unmaintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-**This package is unmaintained:** Active work is not occuring on this package. For an active fork of the package, see [Format.jl](https://github.com/JuliaString/Format.jl).
+> [!WARNING]
+> This package is unmaintained: Active work is not occuring on this package. For an active fork of the package, see [Format.jl](https://github.com/JuliaString/Format.jl).
 
 # Formatting
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**This package is unmaintained:** Active work is not occuring on this package. For an active fork of the package, see [Format.jl](https://github.com/JuliaString/Format.jl).
+
 # Formatting
 
 This package offers Python-style general formatting and c-style numerical formatting (for speed).

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 This package offers Python-style general formatting and c-style numerical formatting (for speed).
 
-| **PackageEvaluator**                                            | **Build Status**                                                                                |
-|:---------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
-|[![][pkg-0.6-img]][pkg-0.6-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] [![][codecov-img]][codecov-url] |
+| **PackageEvaluator**                                            | **Build Status**                                                                                | **Repo Status**
+|:---------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|:---------------------------------------------------------------:|
+|[![][pkg-0.6-img]][pkg-0.6-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] [![][codecov-img]][codecov-url] | [![Project Status: Unsupported – The project has reached a stable, usable state but the author(s) have ceased all work on it. A new maintainer may be desired.](https://www.repostatus.org/badges/latest/unsupported.svg)](https://www.repostatus.org/#unsupported) |
 
 
 [travis-img]: https://travis-ci.org/JuliaIO/Formatting.jl.svg?branch=master


### PR DESCRIPTION
Ideally we could also list a point of contact if someone wants to try and revive it and become an owner. 

Alternatively, we could merge @ScottPJones's Format.jl into this as a breaking release of the package (as suggested here: https://github.com/JuliaIO/Formatting.jl/issues/106#issuecomment-1962283166) 

Aditionally, are there any other alternative packages that could be listed? 