### PR TITLE
Add deprecation notice on `using`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,13 @@
 name = "Formatting"
 uuid = "59287772-0a20-5a39-b81b-1366585eb4c0"
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
+Logging = "1"
 julia = "1"
 
 [extras]

--- a/src/Formatting.jl
+++ b/src/Formatting.jl
@@ -1,12 +1,23 @@
 module Formatting
 
     import Base.show
-    using Printf
+    using Printf, Logging
 
     export
         FormatSpec, FormatExpr,
         printfmt, printfmtln, fmt, format,
         sprintf1, generate_formatter
+
+    function __init__()
+        @warn """
+        DEPRECATION NOTICE
+
+        This package has been unmaintained for a while, with some serious
+        bugs comprimising the original purpose of the package. As a result,
+        it has been deprecated - consider using an alternative, such as
+        `Format.jl` (https://github.com/JuliaString/Format.jl) or the `Printf` stdlib directly.
+        """
+    end
 
     include("cformat.jl" )
     include("fmtspec.jl")

--- a/src/Formatting.jl
+++ b/src/Formatting.jl
@@ -8,7 +8,7 @@ module Formatting
         printfmt, printfmtln, fmt, format,
         sprintf1, generate_formatter
 
-    function __init__()
+    if ccall(:jl_generating_output, Cint, ()) == 1
         @warn """
         DEPRECATION NOTICE
 

--- a/src/Formatting.jl
+++ b/src/Formatting.jl
@@ -12,10 +12,15 @@ module Formatting
         @warn """
         DEPRECATION NOTICE
 
-        This package has been unmaintained for a while, with some serious
-        bugs comprimising the original purpose of the package. As a result,
+        Formatting.jl has been unmaintained for a while, with some serious
+        correctness bugs compromising the original purpose of the package. As a result,
         it has been deprecated - consider using an alternative, such as
         `Format.jl` (https://github.com/JuliaString/Format.jl) or the `Printf` stdlib directly.
+
+        If your are not using Formatting.jl as a direct dependency, please consider
+        opening an issue on any packages your are using that do use it as a dependency.
+        From Julia 1.9 onwards, you can query `]why Formatting` to figure out which
+        package originally brings it in as a dependency.
         """
     end
 

--- a/src/Formatting.jl
+++ b/src/Formatting.jl
@@ -17,8 +17,8 @@ module Formatting
         it has been deprecated - consider using an alternative, such as
         `Format.jl` (https://github.com/JuliaString/Format.jl) or the `Printf` stdlib directly.
 
-        If your are not using Formatting.jl as a direct dependency, please consider
-        opening an issue on any packages your are using that do use it as a dependency.
+        If you are not using Formatting.jl as a direct dependency, please consider
+        opening an issue on any packages you are using that do use it as a dependency.
         From Julia 1.9 onwards, you can query `]why Formatting` to figure out which
         package originally brings it in as a dependency.
         """


### PR DESCRIPTION
This adds a deprecation notice that will be printed on `using Formatting`, to inform users that the package has been deprecated and that they should consider using a different package.

This is intended to be released in conjunction with #111. This will also need a release to General, since it bumps the version.